### PR TITLE
Fix Build Failure

### DIFF
--- a/src/components/portfolio/portfolio.js
+++ b/src/components/portfolio/portfolio.js
@@ -19,6 +19,7 @@ function Portfolio() {
 
     useEffect(() => {
         processSortAndFilter();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sortOrder, filterProject]);
 
     const processSortAndFilter = () => {


### PR DESCRIPTION
This pull request includes a minor update to the `Portfolio` component to address an ESLint warning. The change disables the `react-hooks/exhaustive-deps` rule for the `useEffect` dependency array to prevent unnecessary linting errors.

Code quality improvement:

* [`src/components/portfolio/portfolio.js`](diffhunk://#diff-43fba98efc4202d2c0ebeacfe6c70f2701fa8a1b1d0d97f7a5429b18243e477dR22): Added a comment to disable the `react-hooks/exhaustive-deps` ESLint rule for the `useEffect` dependency array.