### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file. The change enforces consistent line endings by setting `text=auto` and `eol=lf`.